### PR TITLE
Fixed Broken URL in README / Install.ps1

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -1,6 +1,6 @@
 # Run this in an administrative PowerShell prompt to install the InvokeADCheck PowerShell module:
 #
-# iex (New-Object Net.WebClient).DownloadString("https://github.com/sensepost/InvokeADCheck/raw/master/Install.ps1")
+# iex(New-Object Net.WebClient).DownloadString("https://raw.githubusercontent.com/sensepost/InvokeADCheck/refs/heads/main/Install.ps1")
 
 # Some general variables
 $ModuleName = 'InvokeADCheck'

--- a/Install.ps1
+++ b/Install.ps1
@@ -4,7 +4,7 @@
 
 # Some general variables
 $ModuleName = 'InvokeADCheck'
-$DownloadURL = 'https://github.com/sensepost/InvokeADCheck/raw/master/release/InvokeADCheck-current.zip'
+$DownloadURL = 'https://github.com/sensepost/InvokeADCheck/raw/refs/heads/main/release/InvokeADCheck-current.zip'
 
 # Download and install the module
 $webclient = New-Object System.Net.WebClient

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Optional:
 To install the module directly, run the following PowerShell command:
 
 ```PowerShell
-iex(New-Object Net.WebClient).DownloadString("https://github.com/sensepost/InvokeADCheck/raw/master/Install.ps1")
+iex(New-Object Net.WebClient).DownloadString("https://raw.githubusercontent.com/sensepost/InvokeADCheck/refs/heads/main/Install.ps1")
 
 Import-Module .\InvokeADCheck.psm1
 ```


### PR DESCRIPTION
Fixed a broken URL in both `README.md` and `Install.ps1`. Now working correctly.

![Screenshot 2025-01-02 at 14 35 47](https://github.com/user-attachments/assets/fd306932-365b-49ae-b3a7-5dc2060f8a3d)
